### PR TITLE
 C extension module: Add Makefile for building C Python extension module

### DIFF
--- a/purec-python/Makefile
+++ b/purec-python/Makefile
@@ -1,0 +1,32 @@
+# Compiler and flags
+CC = gcc
+CFLAGS = -Wall -Wextra -fPIC
+
+# Automatically detect Python path and include directory
+PYTHON_PATH := $(shell which python)
+PYTHON_INCLUDE := $(shell python -c "import sysconfig; print(sysconfig.get_path('include'))")
+
+# Target shared object
+TARGET = example.so
+
+# Source file
+SRC = example.c
+
+# Default target
+all: $(TARGET)
+
+# Rule to build the shared object
+$(TARGET): $(SRC)
+	$(CC) $(CFLAGS) -shared -o $@ $< -I$(PYTHON_INCLUDE)
+
+# Clean rule
+clean:
+	rm -f $(TARGET)
+
+# Print Python paths (for debugging)
+print-python-paths:
+	@echo "Python executable: $(PYTHON_PATH)"
+	@echo "Python include directory: $(PYTHON_INCLUDE)"
+
+# Phony targets
+.PHONY: all clean print-python-paths


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new build configuration that enables seamless compilation of a shared object for use with Python.
	- Automatic detection of Python installation paths to simplify the build process.
	- Added a `clean` rule to facilitate easy cleanup of generated files.
	- Included a debugging target to help users verify Python executable and include directory paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->